### PR TITLE
Removing trailing / for proxypass

### DIFF
--- a/apache/proxy-to-virtual-path.conf
+++ b/apache/proxy-to-virtual-path.conf
@@ -26,5 +26,5 @@ Define DS_ADDRESS backendserver-address
 </Location>
 
 ProxyPassMatch ^\${VPATH}(.*)(\/websocket)$ "ws://${DS_ADDRESS}/$1$2"
-ProxyPass ${VPATH} "http://${DS_ADDRESS}/"
-ProxyPassReverse ${VPATH} "http://${DS_ADDRESS}/"
+ProxyPass ${VPATH} "http://${DS_ADDRESS}"
+ProxyPassReverse ${VPATH} "http://${DS_ADDRESS}"


### PR DESCRIPTION
I had to remove the trailing slash for proxy to virtual path to work.