### PR TITLE
Performance & Convenience Tweaks for NGINX HTTP to HTTPS Proxy

### DIFF
--- a/nginx/proxy-https-to-http.conf
+++ b/nginx/proxy-https-to-http.conf
@@ -64,7 +64,10 @@ server {
 
   ssl_prefer_server_ciphers   on;
 
-  add_header Strict-Transport-Security max-age=31536000;
+  ## [Optional] Before enabling Strict-Transport-Security headers, ensure your server is properly configured for SSL.
+  ## This directive informs the browser to always use HTTPS. For more info see:
+  ## - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+  # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   # add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
 

--- a/nginx/proxy-https-to-http.conf
+++ b/nginx/proxy-https-to-http.conf
@@ -41,7 +41,7 @@ server {
 
   ## Redirects all traffic to the HTTPS host
   root /nowhere; ## root doesn't have to be a valid path since we are redirecting
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$server_name:443$request_uri;
 }
 
 server {

--- a/nginx/proxy-https-to-http.conf
+++ b/nginx/proxy-https-to-http.conf
@@ -40,7 +40,6 @@ server {
   server_tokens off;
 
   ## Redirects all traffic to the HTTPS host
-  root /nowhere; ## root doesn't have to be a valid path since we are redirecting
   return 301 https://$server_name:443$request_uri;
 }
 


### PR DESCRIPTION
Makes the following adjustments to the NGINX HTTP to HTTPS config:

- Removes `root` directive in the HTTP server block, I don't believe this has any functional use.
- Replaces `rewrite` directive with `return` directive for the HTTP redirect. This is for performance and readability, and is advised [by NGINX here](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#taxing-rewrites).
- Disable the Strict-Transport-Security header by default, since this can cause headaches when doing initial setup and isn't critical to secure SSL transport.
- Modify suggested Strict-Transport-Security header to include subdomains and be sent always.

I'm pretty new to NGINX, but these are some things I've observed and found while messing around. Please take a close look at the changes and let me know if I'm ignorant of something. Thanks!