### PR TITLE
[apache] Change websocket tunneling directive from a websocket-only U…

### DIFF
--- a/apache/minimal.conf
+++ b/apache/minimal.conf
@@ -5,6 +5,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 
@@ -18,6 +19,9 @@ RequestHeader setifempty X-Forwarded-Proto http
 RequestHeader setifempty X-Forwarded-Host %{THE_HOST}e
 ProxyAddHeaders Off
 
-ProxyPassMatch (.*)(\/websocket)$ "ws://backendserver-address/$1$2"
+RewriteEngine on
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^/?(.*) "ws://backendserver-address/$1" [P,L]
 ProxyPass / "http://backendserver-address/"
 ProxyPassReverse / "http://backendserver-address/"

--- a/apache/proxy-https-to-http.conf
+++ b/apache/proxy-https-to-http.conf
@@ -10,6 +10,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule ssl_module modules/mod_ssl.so
@@ -42,6 +43,9 @@ RequestHeader setifempty X-Forwarded-Proto https
 RequestHeader setifempty X-Forwarded-Host %{THE_HOST}e
 ProxyAddHeaders Off
 
-ProxyPassMatch (.*)(\/websocket)$ "ws://backendserver-address/$1$2"
+RewriteEngine on
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^/?(.*) "ws://backendserver-address/$1" [P,L]
 ProxyPass / "http://backendserver-address/"
 ProxyPassReverse / "http://backendserver-address/"

--- a/apache/proxy-https-to-https.conf
+++ b/apache/proxy-https-to-https.conf
@@ -10,6 +10,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule ssl_module modules/mod_ssl.so
@@ -46,6 +47,9 @@ RequestHeader setifempty X-Forwarded-Proto https
 RequestHeader setifempty X-Forwarded-Host %{THE_HOST}e
 ProxyAddHeaders Off
 
-ProxyPassMatch (.*)(\/websocket)$ "wss://backendserver-address/$1$2"
+RewriteEngine on
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^/?(.*) "wss://backendserver-address/$1" [P,L]
 ProxyPass / "https://backendserver-address/"
 ProxyPassReverse / "https://backendserver-address/"

--- a/apache/proxy-to-virtual-path.conf
+++ b/apache/proxy-to-virtual-path.conf
@@ -5,6 +5,7 @@ LoadModule unixd_module modules/mod_unixd.so
 LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 
@@ -25,6 +26,9 @@ Define DS_ADDRESS backendserver-address
   ProxyAddHeaders Off
 </Location>
 
-ProxyPassMatch ^\${VPATH}(.*)(\/websocket)$ "ws://${DS_ADDRESS}/$1$2"
+RewriteEngine on
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^\${VPATH}/?(.*) "ws://${DS_ADDRESS}/$1" [P,L]
 ProxyPass ${VPATH} "http://${DS_ADDRESS}"
 ProxyPassReverse ${VPATH} "http://${DS_ADDRESS}"


### PR DESCRIPTION
…RL to universal one.

https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html

sock.js has websocket-only url tail `../websocket`
socket.io uses same websocket and xhr url with difference in query params.

`RewriteCond `method works with both libraries